### PR TITLE
Show players on small screens

### DIFF
--- a/src/public/js/game-view.vue
+++ b/src/public/js/game-view.vue
@@ -99,7 +99,6 @@
 		</div>
 		<div
 			id="side-player-statuses"
-			v-if="playerStatusesListMaxWidth > 0"
 			:style="{
 				maxWidth: `${playerStatusesListMaxWidth}px`,
 			}"

--- a/src/public/style/style.scss
+++ b/src/public/style/style.scss
@@ -265,6 +265,13 @@ canvas#new-paint {
 	position: absolute;
 	word-break: break-all;
 }
+
+@media screen and (max-width: 480px) {
+	#side-player-statuses {
+		position: relative;
+	}
+}
+
 ul.player-statuses-list {
 	text-align: left;
 	li {


### PR DESCRIPTION
Make player list visible on small width screens.  Player list appears at bottom of page.